### PR TITLE
fix s:gsub doesn't exist problem

### DIFF
--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -2709,7 +2709,7 @@ endfu
 
 function! s:shellslash(path)
   if exists('+shellslash') && !&shellslash
-    return s:gsub(a:path,'\\','/')
+    return substitute(a:path,'\','/',"g")
   else
     return a:path
   endif


### PR DESCRIPTION
in windows, the condition if (exists('+shellslash') && !&shellslash) will be true
that s:gsub() doesn't exist will be a problem
